### PR TITLE
Add no-op implementation for android, ios, and js

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 TODOs / FIXMEs not quite super important and maybe not yet issues:
 
-* Allow absence of sticky bit via option, if not supported) by FS
+* Allow absence of sticky bit via option, if not supported by FS
 * Check for permissions and set the correctly
 * Implement deletion across partitions if required somehow.
 * Decide whether we early exit on errors or try to delete all paths. Later, this can be a setting. The decision should be documented.

--- a/wastebasket.go
+++ b/wastebasket.go
@@ -1,0 +1,7 @@
+// Package wastebasket allows you to interact with your system trashbin.
+package wastebasket
+
+import "errors"
+
+// ErrPlatformNotSupported indicates that the current platform does not suport trashing files.
+var ErrPlatformNotSupported = errors.New("platform not supported")

--- a/wastebasket_nix.go
+++ b/wastebasket_nix.go
@@ -1,4 +1,4 @@
-//go:build !windows && !darwin
+//go:build !windows && !darwin && !android && !ios && !js
 
 package wastebasket
 

--- a/wastebasket_noop.go
+++ b/wastebasket_noop.go
@@ -1,0 +1,21 @@
+//go:build android || ios || js
+
+package wastebasket
+
+import (
+	"os"
+)
+
+func Trash(paths ...string) error {
+	for _, path := range paths {
+		err := os.RemoveAll(path)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func Empty() error {
+	return nil
+}

--- a/wastebasket_noop.go
+++ b/wastebasket_noop.go
@@ -2,20 +2,10 @@
 
 package wastebasket
 
-import (
-	"os"
-)
-
 func Trash(paths ...string) error {
-	for _, path := range paths {
-		err := os.RemoveAll(path)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return ErrPlatformNotSupported
 }
 
 func Empty() error {
-	return nil
+	return ErrPlatformNotSupported
 }


### PR DESCRIPTION
These platforms do not support trashing files, and they fail to compile with the `nix` implementation due to its use of `x/sys/unix`.