### PR TITLE
Darwin implementation only works for macOS, not iOS

### DIFF
--- a/wastebasket_darwin.go
+++ b/wastebasket_darwin.go
@@ -1,3 +1,5 @@
+//go:build darwin && !ios
+
 package wastebasket
 
 import (


### PR DESCRIPTION
This prevents a build error when building on iOS, which happens due to the presence of both a no-op and darwin implementation for iOS (iOS satisfies both the iOS and darwin build constraints). 